### PR TITLE
Update requirements_dev.txt

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,7 @@ pytest
 coverage
 tox
 flake8
+click
+dataclasses
+tinydb
+tabular


### PR DESCRIPTION
PyCharm 2018.1 Community Edition would not run pytests without adding these additional modules